### PR TITLE
Code cleanup to remove static queue names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG COMMIT
 ARG BRANCH
 
 RUN apt-get update -y && \
-    apt-get install -y wget && \
+    apt-get install -y wget python-setuptools && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /kb/runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV PYTHONPATH=/kb/runtime/lib/python3.6/site-packages/
 ENV PATH="/root/bin:/root/source:${PATH}"
 
 LABEL org.label-schema.build-date=$BUILD_DATE \
-      org.label-schema.vcs-url="https://github.com/CheyenneNS/SystemMetrics" \
+      org.label-schema.vcs-url="https://github.com/kbase/SystemMetrics" \
       org.label-schema.vcs-ref=$COMMIT \
       org.label-schema.schema-version="1.0.0-rc1" \
       us.kbase.vcs-branch=$BRANCH  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG COMMIT
 ARG BRANCH
 
 RUN apt-get update -y && \
-    apt-get install -y wget python-setuptools && \
+    apt-get install -y wget && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /kb/runtime
@@ -23,7 +23,7 @@ COPY bin /root/bin
 RUN cd /root/bin && wget https://github.com/kbase/dockerize/raw/master/dockerize-linux-amd64-v0.6.1.tar.gz && \
     tar xzf dockerize-linux-amd64-v0.6.1.tar.gz && \
     rm dockerize-linux-amd64-v0.6.1.tar.gz && \
-    easy_install --no-deps /tmp/biokbase-0.0.1-py3.6.egg
+    python3 /usr/local/lib/python3.6/site-packages/setuptools/command/easy_install.py --no-deps /tmp/biokbase-0.0.1-py3.6.egg
 
 COPY source /root/source
 WORKDIR /root/source

--- a/source/PartitionableSlots.py
+++ b/source/PartitionableSlots.py
@@ -40,4 +40,3 @@ class PartitionableSlot():
 
     def __repr__(self):
         return str(vars(self))
-    

--- a/source/calculate_queue_resources.py
+++ b/source/calculate_queue_resources.py
@@ -4,8 +4,10 @@ from statistics import mean
 
 
 def average_times(queue_dict):
-    """average_times is a helper function for get_job_info that takes an array of run times and queue times for each job run in a queue
-    and calculates the mean of the array. The function appends the mean as a value into the queue info dictionary in both it's original unit - seconds - and in hours. Returns the queue dictionaries with the appended mean"""
+    """average_times is a helper function for get_job_info that takes an array of run
+    times and queue times for each job run in a queue and calculates the mean of the array.
+    The function appends the mean as a value into the queue info dictionary in both it's
+    original unit - seconds - and in hours. Returns the queue dictionaries with the appended mean"""
     for queue in queue_dict.keys():
         # Collect run_time and q_time arrays
         queue_time_array = queue_dict[queue]["average_q_time_hr"]
@@ -31,7 +33,13 @@ def average_times(queue_dict):
 
 
 def get_job_info(jobs):
-    """get_jobs_info function is the main function to format the job portion of each queue dictionary for system metrics. It iterates through jobs in condor collects all the job information under the 'classad' key and checks which queue its looking at. For each queue it makes a queue_info dictionary that consists of the average run time and average q-time for jobs in the q (calculated by the helper function above) and counts how many jobs running jobs or queued jobs are currently in the queue. Returns a ultimate queue dictionary containing each queue seen as a queue to its sub job info dictionary."""
+    """get_jobs_info function is the main function to format the job portion of each queue
+    dictionary for system metrics. It iterates through jobs in condor collects all the job
+    information under the 'classad' key and checks which queue its looking at. For each queue
+    it makes a queue_info dictionary that consists of the average run time and average q-time
+    for jobs in the q (calculated by the helper function above) and counts how many jobs running
+    jobs or queued jobs are currently in the queue. Returns a ultimate queue dictionary containing
+    each queue seen as a queue to its sub job info dictionary."""
     queue_dict = {}
     # Interate through jobs
     for job in jobs:
@@ -80,7 +88,10 @@ def get_job_info(jobs):
 
 
 def calculate_queues(partionable_slots, queue_info):
-    """Calculate_queues is similar to get_job_info but in terms of memory/cpu/disk usage per queue not job stats. Only slots that are partionable can run jobs and thus have a kb_clientgroup/queue. This function iterates through partitionable slots and for each clientgroup/queue it sees it collection info on it's system usage."""
+    """Calculate_queues is similar to get_job_info but in terms of memory/cpu/disk
+    usage per queue not job stats. Only slots that are partionable can run jobs and
+    thus have a kb_clientgroup/queue. This function iterates through partitionable
+    slots and for each clientgroup/queue it sees it collection info on it's system usage."""
 
     data_storage_types = ['cpus', 'memory_mb', 'disk_kb',
                           'disk_kb_reserved', 'memory_mb_reserved', 'cpus_reserved',
@@ -126,7 +137,9 @@ def calculate_queues(partionable_slots, queue_info):
 
 
 def calculate_queues_total(partionable_slots, queue_dict):
-    """Calculate_queues_total primarily relies on a helper function 'calculate queues' to calculate the total usage (disk/cpu/memory) per queue. Once the total system usage has been calculated it converts the units from Kb to Gb"""
+    """Calculate_queues_total primarily relies on a helper function 'calculate queues'
+    to calculate the total usage (disk/cpu/memory) per queue. Once the total system
+    usage has been calculated it converts the units from Kb to Gb"""
     queue_info = calculate_queues(partionable_slots, queue_dict)
     for queue, memory_dict in queue_info.items():
         # Available Usage

--- a/source/calculate_queue_resources.py
+++ b/source/calculate_queue_resources.py
@@ -19,21 +19,20 @@ def average_times(queue_dict):
             queue_time_ave = mean(queue_time_array)
             run_time_ave = mean(run_time_array)
         # Convert mean to hours from seconds
-        average_qtime_hours = floor(queue_time_ave // 3600 )
-        average_runtime_hours = floor(run_time_ave // 3600 )
+        average_qtime_hours = floor(queue_time_ave // 3600)
+        average_runtime_hours = floor(run_time_ave // 3600)
         # Add run time and q time values in seconds and hours to dictionary
         queue_dict[queue]["average_q_time_sec"] = floor(queue_time_ave)
         queue_dict[queue]["average_run_time_sec"] = floor(run_time_ave)
         queue_dict[queue]["average_run_time_hr"] = average_runtime_hours
-        queue_dict[queue]["average_q_time_hr"] = average_qtime_hours        
+        queue_dict[queue]["average_q_time_hr"] = average_qtime_hours
 
     return queue_dict
+
 
 def get_job_info(jobs):
     """get_jobs_info function is the main function to format the job portion of each queue dictionary for system metrics. It iterates through jobs in condor collects all the job information under the 'classad' key and checks which queue its looking at. For each queue it makes a queue_info dictionary that consists of the average run time and average q-time for jobs in the q (calculated by the helper function above) and counts how many jobs running jobs or queued jobs are currently in the queue. Returns a ultimate queue dictionary containing each queue seen as a queue to its sub job info dictionary."""
     queue_dict = {}
-    queue_times = []
-    run_times = []
     # Interate through jobs
     for job in jobs:
         # All job info for KBase jobs in Condor is under 'classad'
@@ -58,7 +57,7 @@ def get_job_info(jobs):
             queue_array = queue_dict[queue]["average_q_time_hr"]
             # Get times
             epoch_time_now = int(time.time())
-            # Current run time for a job is when the job started subtracted the current time on the system when checked 
+            # Current run time for a job is when the job started subtracted the current time on the system when checked
             run_time = epoch_time_now - start_date
             # Q time is when the job started minus when the job was first queued
             queue_time = start_date - q_date
@@ -70,13 +69,13 @@ def get_job_info(jobs):
             q_date = job['qdate']
             queue_array = queue_dict[queue]["average_q_time_hr"]
             epoch_time_now = int(time.time())
-            # Thus, the current amount of time this job has spent in the queue is the the current time minus the time it was queued 
+            # Thus, the current amount of time this job has spent in the queue is the the current time minus the time it was queued
             queue_time = epoch_time_now - q_date
             queue_array.append(queue_time)
             queue_dict[queue]['total_in_queue'] += 1
     # Send final queue dict to helper function to calculate the run time and q_time means
     formatted_dict = average_times(queue_dict)
-                
+
     return formatted_dict
 
 
@@ -90,7 +89,7 @@ def calculate_queues(partionable_slots, queue_info):
     for slot in partionable_slots:
         machine = partionable_slots[slot]
         queue = machine.clientgroup
-        # If queue has already been seen, simply the sum the system usage info for this slot. 
+        # If queue has already been seen, simply the sum the system usage info for this slot.
         if queue in queue_info.keys():
             queue_memory = queue_info[queue]
             # Available
@@ -107,7 +106,7 @@ def calculate_queues(partionable_slots, queue_info):
             queue_memory['disk_actual'] += machine.disk_actual
             queue_info[machine.clientgroup] = queue_memory
         else:
-            # If queue hasn't been seen create a dictionary with all the data storage types 
+            # If queue hasn't been seen create a dictionary with all the data storage types
             # Initalize dictionary objects
             queue_memory = dict.fromkeys(data_storage_types, 0)
             # Available
@@ -124,6 +123,7 @@ def calculate_queues(partionable_slots, queue_info):
             queue_memory['disk_actual'] = machine.disk_actual
             queue_info[machine.clientgroup] = queue_memory
     return queue_info
+
 
 def calculate_queues_total(partionable_slots, queue_dict):
     """Calculate_queues_total primarily relies on a helper function 'calculate queues' to calculate the total usage (disk/cpu/memory) per queue. Once the total system usage has been calculated it converts the units from Kb to Gb"""

--- a/source/calculate_total_memory_resources.py
+++ b/source/calculate_total_memory_resources.py
@@ -2,7 +2,7 @@ from math import floor
 
 
 def calculate_total_cpus_memory_disk(partionable_slots):
-    """This function calculates the memory resources/allocated - available, reserved, actual - for a given machine. 
+    """This function calculates the memory resources/allocated - available, reserved, actual - for a given machine.
        The memory resources are formatted to a dictionary that is returned."""
 
     # Initiate memory variables
@@ -23,7 +23,7 @@ def calculate_total_cpus_memory_disk(partionable_slots):
         cpus += p_slot.totalslotcpus
         memory_mb += p_slot.totalmemory
         disk_kb += p_slot.totaldisk
-        # Reserved 
+        # Reserved
         cpus_reserved += p_slot.childcpus_reserved
         memory_mb_reserved += p_slot.childmemory_reserved
         disk_kb_reserved += p_slot.childdisk_reserved
@@ -48,7 +48,7 @@ def calculate_total_cpus_memory_disk(partionable_slots):
     available = {'disk_gb': disk_gb_available, 'memory_gb': memory_gb_available, 'cpus': cpus}
     reserved = {'disk_gb': disk_gb_reserved, 'memory_gb': memory_gb_reserved, 'cpus': cpus_reserved}
     actual = {'disk_gb': disk_gb_actual, 'memory_gb': memory_gb_actual}
-    # Dictionary of memory resources 
+    # Dictionary of memory resources
     resources = {'available': available,
                  'reserved': reserved,
                  'actual': actual}

--- a/source/client.py
+++ b/source/client.py
@@ -1,15 +1,23 @@
 import socket
 import json
 import os
-host = os.environ["ELASTICSEARCH_HOST"]
+
+host = os.environ.get("ELASTICSEARCH_HOST")
+if host is None:
+    print("No value set for ELASTICSEARCH_HOST environment variable, output will be send to stdout")
+
+
 def to_logstashJson(log_d):
 
     port = 9000
     json_data = json.dumps(log_d)
     json_data += '\n'
 
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.connect((host, port))
-    s.sendall(json_data.encode())
+    if host is not None:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect((host, port))
+        s.sendall(json_data.encode())
+    else:
+        print(json_data)
 
     return None

--- a/source/generate_slot_report.py
+++ b/source/generate_slot_report.py
@@ -1,15 +1,16 @@
-from collections import defaultdict, Counter
+from collections import Counter
+
 
 def generate_cg_report(partionable_slots):
     print("Creating all machines report")
+
     report = {'claimed': 0, 'unclaimed': 0}
     cg_count = Counter()
-    queues = ["njs", "bigmemlong", "bigmem", "concierge", "kb_upload"]
-    
+
     for slot in partionable_slots:
         machine = partionable_slots[slot]
         queue = machine.clientgroup
-        cg_count[machine.clientgroup]+=1
+        cg_count[machine.clientgroup] += 1
         if queue not in report.keys():
             report[queue] = {'claimed': 0, 'unclaimed': 0}
         if(machine.claimed):
@@ -18,5 +19,5 @@ def generate_cg_report(partionable_slots):
         else:
             report['unclaimed'] += 1
             report[queue]["unclaimed"] += 1
-            
+
     return(report)

--- a/source/upload_system_metrics.py
+++ b/source/upload_system_metrics.py
@@ -1,5 +1,3 @@
-# UploadErrorLogs                                                                                                     
-#                                                                                                                     
 from get_system_reports import get_system_report
 import time
 import sys


### PR DESCRIPTION
Removed instances of static queue names that had become obsolete. Now generates queue information based on the queues that EE2 reports. Also code cleanup so that flake8 doesn't complain nearly as much.